### PR TITLE
Correct file suffix check when importing files

### DIFF
--- a/goldenverba/ingestion/preprocess.py
+++ b/goldenverba/ingestion/preprocess.py
@@ -109,7 +109,7 @@ def load_file(file_path: Path) -> dict:
     @returns dict - Dictionary of filename (key) and their content (value)
     """
     file_contents = {}
-    file_types = ["txt", "md", "mdx"]
+    file_types = [".txt", ".md", ".mdx"]
 
     if file_path.suffix not in file_types:
         msg.warn(f"{file_path.suffix} not supported")


### PR DESCRIPTION
From documentation for suffix property
`The final component's last suffix, if any. This includes the leading period. For example: '.txt'`