### PR TITLE
Add support for Palm, Claude-2, Cohere Llama2, CodeLlama (100+LLMs) 

### DIFF
--- a/goldenverba/retrieval/advanced_engine.py
+++ b/goldenverba/retrieval/advanced_engine.py
@@ -2,7 +2,7 @@ from goldenverba.retrieval.simple_engine import SimpleVerbaQueryEngine
 
 import os
 from wasabi import msg
-import openai
+import litellm
 
 
 class AdvancedVerbaQueryEngine(SimpleVerbaQueryEngine):
@@ -41,11 +41,9 @@ class AdvancedVerbaQueryEngine(SimpleVerbaQueryEngine):
         msg.info(
             f"Combined context of all chunks and their weighted windows ({len(context)} characters)"
         )
-
-        openai.api_key = os.environ.get("OPENAI_API_KEY", "")
         try:
             msg.info(f"Starting API call to answer {query_string}")
-            completion = openai.ChatCompletion.create(
+            completion = litellm.completion(
                 model=model,
                 messages=[
                     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 weaviate-client>=3.23.1
 python-dotenv>=1.0.0
 openai>=0.27.9
+litellm>=0.1.500
 black>=23.7.0
 wasabi>=1.1.2
 fastapi>=0.102.0


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```