### PR TITLE
Fix `nlp` being overwritten and remove unused imports

### DIFF
--- a/goldenverba/ingestion/import_data.py
+++ b/goldenverba/ingestion/import_data.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from wasabi import msg  # type: ignore[import]

--- a/goldenverba/ingestion/import_weaviate.py
+++ b/goldenverba/ingestion/import_weaviate.py
@@ -1,5 +1,3 @@
-import os
-
 from wasabi import msg  # type: ignore[import]
 import spacy
 

--- a/goldenverba/ingestion/init_cache.py
+++ b/goldenverba/ingestion/init_cache.py
@@ -1,4 +1,3 @@
-import os
 from wasabi import msg  # type: ignore[import]
 
 from goldenverba.ingestion.util import setup_client

--- a/goldenverba/ingestion/init_schema.py
+++ b/goldenverba/ingestion/init_schema.py
@@ -1,4 +1,3 @@
-import os
 from wasabi import msg  # type: ignore[import]
 
 from goldenverba.ingestion.util import setup_client

--- a/goldenverba/ingestion/init_suggestion.py
+++ b/goldenverba/ingestion/init_suggestion.py
@@ -1,4 +1,3 @@
-import os
 from wasabi import msg  # type: ignore[import]
 
 from goldenverba.ingestion.util import setup_client

--- a/goldenverba/ingestion/preprocess.py
+++ b/goldenverba/ingestion/preprocess.py
@@ -1,5 +1,4 @@
 import glob
-import os
 import json
 
 from goldenverba.ingestion.util import hash_string

--- a/goldenverba/ingestion/preprocess_weaviate.py
+++ b/goldenverba/ingestion/preprocess_weaviate.py
@@ -24,8 +24,6 @@ def retrieve_documentation(nlp: Language) -> tuple[list[Doc], list[Doc]]:
     """Downloads the Weaviate documentation, preprocesses, and chunks it. Returns a list of full documents and a list of chunks
     @returns tuple[list[Document], list[Document]] - A tuple of list of documents and list of chunks
     """
-    nlp = spacy.blank("en")
-
     weaviate_documentation = download_from_github(
         nlp,
         "weaviate",

--- a/goldenverba/retrieval/interface.py
+++ b/goldenverba/retrieval/interface.py
@@ -1,4 +1,3 @@
-import weaviate
 from weaviate import Client
 
 from goldenverba.ingestion.util import setup_client

--- a/goldenverba/server/api.py
+++ b/goldenverba/server/api.py
@@ -11,7 +11,6 @@ from fastapi.responses import FileResponse
 from pathlib import Path
 from pydantic import BaseModel
 
-from goldenverba.retrieval.simple_engine import SimpleVerbaQueryEngine
 from goldenverba.retrieval.advanced_engine import AdvancedVerbaQueryEngine
 
 from dotenv import load_dotenv


### PR DESCRIPTION
Hi to whoever is reading this PR! 🤗 

## Description

After playing around with the codebase for a bit, I found out that there were some unused imports and also spotted what I considered a bug which was that the `nlp` pipeline from `spaCy` that was provided via keyword arg was being overwritten, as the new `nlp` pipeline was being initialised empty as `nlp = spacy.blank("en")`.

## What's next?

I think that a `pre-commit` configuration file could be included (I'm happy to do so in case you're using `pre-commit` on another repository I can just clone it).