### PR TITLE
Azure ai compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ Regardless of your chosen deployment method, you'll need to specify the followin
 ## Using Azure OpenAI
 
 You can use Azure OpenAI instead of OpenAI. You simply need to set these environment variables:
-- OPENAI_API_TYPE="azure"
-- OPENAI_API_BASE="<your endpoint>"
-- AZURE_OPENAI_RESOURCE_NAME to your resourceName, which is XXX when your endpoint is http://XXX.openai.azure.com"
-- You might want to set AZURE_WAIT_BETWEEN_QUERIES=10 if you have a query-per-minute quota on your Azure AI account.
+- ```OPENAI_API_TYPE="azure"```
+- ```OPENAI_API_BASE="<your endpoint>"```
+- ```OPENAI_API_KEY="<your Azure OpenAI key>"```
+- Optionnaly ```OPENAI_API_VERSION```
+- ```AZURE_OPENAI_RESOURCE_NAME``` to your resourceName, which is XXX when your endpoint is http://XXX.openai.azure.com"
+- You might want to set ```VERBA_WAIT_TIME_BETWEEN_INGESTION_QUERIES=10``` (or less) if you have a query-per-minute quota on your Azure AI account.
 
 You will also have to use a model that is deployed on your AzureAI server. Model can be chosen using the `--model` argument when launching verba.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ Regardless of your chosen deployment method, you'll need to specify the followin
 - ```VERBA_URL=http://your-weaviate-server:8080```
 - ```VERBA_API_KEY=your-weaviate-database-key```
 
+## Using Azure OpenAI
+
+You can use Azure OpenAI instead of OpenAI. You simply need to set these environment variables:
+- OPENAI_API_TYPE="azure"
+- OPENAI_API_BASE="<your endpoint>"
+- AZURE_OPENAI_RESOURCE_NAME to your resourceName, which is XXX when your endpoint is http://XXX.openai.azure.com"
+- You might want to set AZURE_WAIT_BETWEEN_QUERIES=10 if you have a query-per-minute quota on your Azure AI account.
+
+You will also have to use a model that is deployed on your AzureAI server. Model can be chosen using the `--model` argument when launching verba.
+
 # 📦 Data Import Guide
 
 Verba offers straightforward commands to import your data for further interaction. Before you proceed, please be aware that importing data will **incur costs** based on your configured OpenAI access key.


### PR DESCRIPTION
Some slight changes have to be done when using Azure: 
- "deploymentId" and "resourceName" have to be setup in text2vec-openai config. 
- The key should be provided to weaviate as X-Azure-Api-Key, 
- When calling openai.ChatCompletion, deployment_id should be set (same name as the model name)

Also AzureAI is using per-minute quotas, which means it might fail at data ingestion stage. To avoid that we add an optional waiting time between ingestion queries.

All parameters are set using environment variables, documented in the README.