### PR TITLE
Added Self Hosted Unstructured Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,14 @@ LLAMA2-7B-CHAT-HF=True
 ```
 
 ## Unstructured
-
 Verba supports importing documents through Unstructured (e.g .pdf). To use them you need the `UNSTRUCTURED_API_KEY` environment variable. You can get it from [Unstructured](https://unstructured.io/)
 
 ```
 UNSTRUCTURED_API_KEY=YOUR-UNSTRUCTURED-KEY
+UNSTRUCTURED_API_URL=YOUR-SELF-HOSTED-INSTANCE # If you are self hosting, in the form of `http://localhost:8000/general/v0/general`
 ```
+
+
 
 ## Github
 

--- a/goldenverba/components/reader/unstructuredpdf.py
+++ b/goldenverba/components/reader/unstructuredpdf.py
@@ -87,7 +87,9 @@ class UnstructuredPDF(Reader):
         """
         documents = []
 
-        url = "https://api.unstructured.io/general/v0/general"
+        url = os.environ.get(
+            "UNSTRUCTURED_API_URL", "https://api.unstructured.io/general/v0/general"
+        )
 
         headers = {
             "accept": "application/json",
@@ -140,7 +142,9 @@ class UnstructuredPDF(Reader):
             msg.warn(f"{file_path.suffix} not supported")
             return []
 
-        url = "https://api.unstructured.io/general/v0/general"
+        url = os.environ.get(
+            "UNSTRUCTURED_API_URL", "https://api.unstructured.io/general/v0/general"
+        )
 
         headers = {
             "accept": "application/json",


### PR DESCRIPTION
Howdy 👋🏼

I'd like to use this project with my own [self hosted](https://github.com/Unstructured-IO/unstructured-api#dizzy-instructions-for-using-the-docker-image) instance of Unstructured, and I noticed it wasn't an option. I added it near the code that interfaces with Unstructured and updated the README to include the option. 

It shouldn't break existing deployments, as I kept the canonical unstructured API as the default.

