### PR TITLE
fix: add dynamically branch name, defaults to main

### DIFF
--- a/goldenverba/components/reader/githubreader.py
+++ b/goldenverba/components/reader/githubreader.py
@@ -19,7 +19,7 @@ class GithubReader(Reader):
         super().__init__()
         self.name = "GithubReader"
         self.requires_env = ["GITHUB_TOKEN"]
-        self.description = "Downloads only text files from a GitHub repository and ingests it into Verba. Use this format {owner}/{repo}/{folder}"
+        self.description = "Downloads only text files from a GitHub repository and ingests it into Verba. Use this format {owner}/{repo}/{branch}/{folder}"
         self.input_form = InputForm.INPUT.value
 
     def load(
@@ -93,12 +93,10 @@ class GithubReader(Reader):
         split = path.split("/")
         owner = split[0]
         repo = split[1]
-        folder_path = ""
-        if len(split) > 2:
-            folder_path = "/".join(split[2:])
+        branch = split[2] if len(split) > 2 else "main"
+        folder_path = "/".join(split[3:]) if len(split) > 3 else ""
 
-        # Path should be owner/repo
-        url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/main?recursive=1"
+        url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1"
         headers = {
             "Authorization": f"token {os.environ.get('GITHUB_TOKEN', '')}",
             "Accept": "application/vnd.github.v3+json",
@@ -131,8 +129,9 @@ class GithubReader(Reader):
         split = path.split("/")
         owner = split[0]
         repo = split[1]
+        branch = split[2] if len(split) > 2 else "main"
 
-        url = f"https://api.github.com/repos/{owner}/{repo}/contents/{file_path}"
+        url = f"https://api.github.com/repos/{owner}/{repo}/contents/{file_path}?ref={branch}"
         headers = {
             "Authorization": f"token {os.environ.get('GITHUB_TOKEN', '')}",
             "Accept": "application/vnd.github.v3+json",


### PR DESCRIPTION
This is a fix for #71

goldenverba/components/reader/githubreader.py
- The description of the GithubReader class has been updated to include the {branch} placeholder in the format string.
- The fetch_docs method has been refactored to correctly handle the GitHub branch and folder path. It now accounts for the possibility of a branch being specified and defaults to "main" if not.
- The download_file method has been updated to include the branch in the URL when fetching file contents from GitHub.

Unfortunately, I didn't handle cases where the branch can be called "fix/something" as is has slashes like the folder path, but I think the main problem is addressed for this specific issue. 

Any suggestions?