### PR TITLE
feat: Endpoint for importing directories additionally to files

### DIFF
--- a/goldenverba/server/api.py
+++ b/goldenverba/server/api.py
@@ -234,7 +234,7 @@ async def reset_verba(payload: ResetPayload):
     return JSONResponse(status_code=200, content={})
 
 
-@app.post("/api/import_collection")
+@app.post("/api/import_directory")
 async def import_collection(payload: ImportCollectionPayload):
     logging = []
 

--- a/goldenverba/server/api.py
+++ b/goldenverba/server/api.py
@@ -236,6 +236,15 @@ async def reset_verba(payload: ResetPayload):
 
 @app.post("/api/import_directory")
 async def import_collection(payload: ImportCollectionPayload):
+    """
+    Receive a list of directories and reads all files from it reusing the logic from /api/import
+
+
+    Example call
+    ```
+    http POST localhost:8000/api/import_directory directories:='["YOUR_DIRECTORY_FULL_PATH"]' config:='{}'
+    ```
+    """
     logging = []
 
     if production:
@@ -252,7 +261,11 @@ async def import_collection(payload: ImportCollectionPayload):
         files: list[FileData] = []
         text_values: list[str] = []
         for dir in payload.directories:
-            onlyfiles = [(dir, f) for f in os.listdir(dir) if os.path.isfile(os.path.join(dir, f))]
+            onlyfiles = [
+                (dir, f)
+                for f in os.listdir(dir)
+                if os.path.isfile(os.path.join(dir, f))
+            ]
             for dir, file in onlyfiles:
                 with open(os.path.join(dir, file), "r") as fl:
                     file_ = FileData(

--- a/goldenverba/server/types.py
+++ b/goldenverba/server/types.py
@@ -49,6 +49,9 @@ class ImportPayload(BaseModel):
     textValues: list[str]
     config: dict
 
+class ImportCollectionPayload(BaseModel):
+    directories: list[str]
+    config: dict
 
 class ConfigPayload(BaseModel):
     config: dict


### PR DESCRIPTION
This PR Adds:

- `/api/import_directory` endpoint so the user can upload complete directories additionally to files. It reuses most of the `/api/import/` logic.


**Example call**

```
http POST localhost:8000/api/import_directory directories:='["YOUR_DIRECTORY_FULL_PATH"]' config:='{}'
```

I added this because I needed it and I think it might be helpful for other users. Please let me know if you want to provide this feature in a different way or approach, I'll be happy to help.


**TODO**

I can take a look at the react code to try and add a button for it to the UI (reviewing it in the meantime)