### PR TITLE
Fix requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
         "pypdf==4.3.0",
         "python-docx==1.1.2",
         "scikit-learn==1.5.1",
-        "langchain-text==splitters-0.2.2"
+        "langchain-text-splitters==0.2.2",
+	"aiohttp==3.9.5"
     ],
     extras_require={
         "dev": ["pytest", "wheel", "twine", "black>=23.7.0", "setuptools"],


### PR DESCRIPTION
setup.py missed two requirements:

"langchain-text-splitters==0.2.2", # typo in original
"aiohttp==3.9.5"