### PR TITLE
Fixed for Docker

### DIFF
--- a/goldenverba/components/embedding/CohereEmbedder.py
+++ b/goldenverba/components/embedding/CohereEmbedder.py
@@ -20,7 +20,7 @@ class CohereEmbedder(Embedder):
             "Vectorizes documents and queries using Cohere"
         )
         self.url = os.getenv("COHERE_BASE_URL", "https://api.cohere.com/v1")
-        models = self.get_models(os.getenv("COHERE_API_KEY", None))
+        models = self.get_models(os.getenv("COHERE_API_KEY", ""))
         self.config = {
             "Model": InputConfig(
                 type="dropdown", value="embed-english-v3.0", description="Select a Cohere Embedding Model", values=models
@@ -65,7 +65,7 @@ class CohereEmbedder(Embedder):
         
 
     def get_models(self, token: str):
-        if token is None:
+        if token == "":
             return ["embed-english-v3.0","embed-multilingual-v3.0","embed-english-light-v3.0","embed-multilingual-light-v3.0"]
         headers = {
                 "Authorization": f"bearer {token}"


### PR DESCRIPTION
Some of the key checks in manage.py don't work with Docker containers: 

- Docker takes environment variables like COHERE_API_KEY from the host system.
- The docker-compose.yaml assigns them to env variables in the container. 
- If COHERE_API_KEY was empty on host, the container gets COHERE_API_KEY=""
- So there IS a COHERE_API_KEY (even if it is an empty string), thus returning a string instead of None.
- The check fails.

My suggestion is using an empty string instead of None as a signifier of an unset env variable

I guess this due to changing to asynchronous database access. 