### PR TITLE
Added char level index for some chunkers, some minor improvements

### DIFF
--- a/goldenverba/components/chunking/HTMLChunker.py
+++ b/goldenverba/components/chunking/HTMLChunker.py
@@ -42,16 +42,25 @@ class HTMLChunker(Chunker):
             # Skip if document already contains chunks
             if len(document.chunks) > 0:
                 continue
-
+            
             for i, chunk in enumerate(text_splitter.split_text(document.content)):
+                
+                chunk_text = ""
+
+                # append title and page content (should only be one header as we are splitting at header so index at 0), if a header is found
+                if len(chunk.metadata) > 0:
+                    chunk_text += list(chunk.metadata.values())[0] + "\n"
+
+                # append page content (always there)
+                chunk_text += chunk.page_content
 
                 document.chunks.append(
                     Chunk(
-                        content=chunk.page_content,
+                        content=chunk_text,
                         chunk_id=i,
-                        start_i=0,
-                        end_i=0,
-                        content_without_overlap=chunk.page_content,
+                        start_i=None,# not implemented as HTML text splitter changes the actual document (removes tags)
+                        end_i=None, 
+                        content_without_overlap=chunk_text,
                     )
                 )
 

--- a/goldenverba/components/chunking/JSONChunker.py
+++ b/goldenverba/components/chunking/JSONChunker.py
@@ -53,14 +53,18 @@ class JSONChunker(Chunker):
             if len(document.chunks) > 0:
                 continue
 
+            char_end_i = -1
             for i, chunk in enumerate(text_splitter.split_text(json_obj)):
+
+                char_start_i = char_end_i + 1
+                char_end_i = char_start_i + len(chunk)
 
                 document.chunks.append(
                     Chunk(
                         content=chunk,
                         chunk_id=i,
-                        start_i=0,
-                        end_i=0,
+                        start_i=None, # not implemented as the splitter modifies the outputs
+                        end_i=None,
                         content_without_overlap=chunk,
                     )
                 )

--- a/goldenverba/components/chunking/MarkdownChunker.py
+++ b/goldenverba/components/chunking/MarkdownChunker.py
@@ -38,6 +38,7 @@ class MarkdownChunker(Chunker):
             ]
         )
 
+        char_end_i = -1
         for document in documents:
 
             # Skip if document already contains chunks
@@ -45,14 +46,26 @@ class MarkdownChunker(Chunker):
                 continue
 
             for i, chunk in enumerate(text_splitter.split_text(document.content)):
+                
+                chunk_text = ""
+
+                # append title and page content (should only be one header as we are splitting at header so index at 0), if a header is found
+                if len(chunk.metadata) > 0:
+                    chunk_text += list(chunk.metadata.values())[0] + "\n"
+
+                # append page content (always there)
+                chunk_text += chunk.page_content
+
+                char_start_i = char_end_i + 1
+                char_end_i = char_start_i + len(chunk_text)
 
                 document.chunks.append(
                     Chunk(
-                        content=chunk.page_content,
+                        content=chunk_text,
                         chunk_id=i,
-                        start_i=0,
-                        end_i=0,
-                        content_without_overlap=chunk.page_content,
+                        start_i=None, # not implemented as text splitter augments the document
+                        end_i=None,
+                        content_without_overlap=chunk_text,
                     )
                 )
 

--- a/goldenverba/components/chunking/RecursiveChunker.py
+++ b/goldenverba/components/chunking/RecursiveChunker.py
@@ -29,6 +29,12 @@ class RecursiveChunker(Chunker):
                 description="Choose how many characters per chunks",
                 values=[],
             ),
+            "Overlap": InputConfig(
+                type="number",
+                value=100,
+                description="Choose how many characters per chunks",
+                values=[],
+            ),
             "Seperators": InputConfig(
                 type="multi",
                 value="",
@@ -58,10 +64,12 @@ class RecursiveChunker(Chunker):
     ) -> list[Document]:
 
         units = int(config["Chunk Size"].value)
+        overlap = int(config["Overlap"].value)
         seperators = config["Seperators"].values
 
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=units,
+            chunk_overlap=overlap,
             length_function=len,
             is_separator_regex=False,
             separators=seperators,
@@ -72,15 +80,26 @@ class RecursiveChunker(Chunker):
             # Skip if document already contains chunks
             if len(document.chunks) > 0:
                 continue
-
+            
+            # char_end_i = -1
             for i, chunk in enumerate(text_splitter.split_text(document.content)):
+
+                # leavingt this commented because this _does_ work but the text splitter strips whitespace and therefore modifies the original doc
+                # if overlap == 0:
+                #     char_start_i = char_end_i + 1
+                #     char_end_i = char_start_i + len(chunk)
+                # else:
+
+                # not implemented because it uses intelligent chunking to find start of token
+                char_start_i = None
+                char_end_i = None
 
                 document.chunks.append(
                     Chunk(
                         content=chunk,
                         chunk_id=i,
-                        start_i=0,
-                        end_i=0,
+                        start_i=char_start_i,
+                        end_i=char_end_i,
                         content_without_overlap=chunk,
                     )
                 )

--- a/goldenverba/components/chunking/TokenChunker.py
+++ b/goldenverba/components/chunking/TokenChunker.py
@@ -57,10 +57,11 @@ class TokenChunker(Chunker):
                         content=document.content,
                         chunk_id=0,
                         start_i=0,
-                        end_i=len(doc),
+                        end_i=len(document.content),
                         content_without_overlap=document.content,
                     )
                 )
+                continue
 
             if overlap >= units:
                 msg.warn(
@@ -78,11 +79,17 @@ class TokenChunker(Chunker):
                 chunk_text = doc[start_i:end_i].text
                 chunk_text_without_overlap = doc[start_i:overlap_start].text
 
+                # char_start_i = doc[start_i].idx
+                if end_i == len(doc):
+                    char_end_i = doc[-1].idx + 1
+                else:
+                    char_end_i = doc[end_i].idx
+
                 doc_chunk = Chunk(
                     content=chunk_text,
                     chunk_id=split_id_counter,
-                    start_i=start_i,
-                    end_i=end_i,
+                    start_i=doc[start_i].idx,
+                    end_i=char_end_i,
                     content_without_overlap=chunk_text_without_overlap,
                 )
 


### PR DESCRIPTION
For most chunkers, the `start_i` and `end_i` were undefined and others were inconsistent. Now, for each chunker, these indices are either `None` or correspond to the character level indices, so that you can index the document from `start_i` to `end_i` as a string and obtain the same chunks as are being output.

Other fixes include:
 - Code Chunker now correctly chunks multiple times if the document is too small, with a default "Chunk Size" config that can be changed.
 - HTML and Markdown chunkers now include the title in the chunk text (which I imagine is important for retrieval)
 - Duplicate chunks are no longer output in some chunkers when the chunk consisted of the whole document (an if statement was catching these but not continuing to the next iteration after)
 - Some minor touch-ups