### PR TITLE
update set_reader to return type bool

### DIFF
--- a/goldenverba/components/managers.py
+++ b/goldenverba/components/managers.py
@@ -91,12 +91,14 @@ class ReaderManager:
 
         return documents, logging
 
-    def set_reader(self, reader: str):
+    def set_reader(self, reader: str) -> bool:
         if reader in self.readers:
             msg.info(f"Setting READER to {reader}")
             self.selected_reader = reader
+            return True
         else:
             msg.warn(f"Reader {reader} not found")
+            return False
 
     def get_readers(self) -> dict[str, Reader]:
         return self.readers

--- a/goldenverba/verba_manager.py
+++ b/goldenverba/verba_manager.py
@@ -85,7 +85,7 @@ class VerbaManager:
         return modified_documents, logging
 
     def reader_set_reader(self, reader: str) -> bool:
-        self.reader_manager.set_reader(reader)
+        return self.reader_manager.set_reader(reader)
 
     def reader_get_readers(self) -> dict[str, Reader]:
         return self.reader_manager.get_readers()


### PR DESCRIPTION
This PR fixes an inconsistency with the type annotations and return types of the `set_reader` method in both `goldenverba/verba_manager.py` and `goldenverba/components/managers.py`