### PR TITLE
avoid premature message submission when using IME

### DIFF
--- a/frontend/app/components/Chat/ChatInterface.tsx
+++ b/frontend/app/components/Chat/ChatInterface.tsx
@@ -94,6 +94,8 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
 
   const [userInput, setUserInput] = useState("");
   const [messages, setMessages] = useState<Message[]>([]);
+  const [isComposing, setIsComposing] = useState(false);
+
   const currentEmbedding = RAGConfig
     ? (RAGConfig["Embedder"].components[RAGConfig["Embedder"].selected].config[
         "Model"
@@ -317,8 +319,16 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
     }
   };
 
+  const handleCompositionStart = () => {
+    setIsComposing(true);
+  }
+
+  const handleCompositionEnd = () => {
+    setIsComposing(false);
+  }
+
   const handleKeyDown = (e: any) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !isComposing) {
       e.preventDefault(); // Prevent new line
       sendUserMessage(); // Submit form
     }
@@ -591,6 +601,8 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
                     : `No documents detected...`
                 }
                 onKeyDown={handleKeyDown}
+                onCompositionStart={handleCompositionStart}
+                onCompositionEnd={handleCompositionEnd}
                 value={userInput}
                 onChange={(e) => {
                   const newValue = e.target.value;


### PR DESCRIPTION
## Description

When using Japanese Input Method Editor (IME), the Enter key is also used for finalizing character conversion. This conflicts with pressing the Enter key to submit a message, and causes premature message submission and frustration for Japanese users who are in the middle of inputting text.

This PR ensures that the Enter key will only send the message if the user is not in the middle of an IME conversion, which should provide a more intuitive experience for users typing in Japanese.

NOTES: not sure but this might also happen in other languages which use IME such as Korean and Chinese.

## Solution

- track whether the user is in the middle of an IME conversion by using the compositionstart and compositionend events
- modify handleKeyDown to only send the message if the Enter key is pressed and the user is not in the middle of an IME conversion.

## Reference

- https://en.wikipedia.org/wiki/Japanese_input_method#Kana_to_kanji_conversion
- https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionstart_event
- https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionend_event