### PR TITLE
Update the Unstructured app URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ ollama run llama3
 
 Verba supports importing documents through Unstructured IO (e.g plain text, .pdf, .csv, and more). To use them you need the `UNSTRUCTURED_API_KEY` and `UNSTRUCTURED_API_URL` environment variable. You can get it from [Unstructured](https://unstructured.io/)
 
-> UNSTRUCTURED_API_URL is set to `https://api.unstructured.io/general/v0/general` by default
+> UNSTRUCTURED_API_URL is set to `https://api.unstructuredapp.io/general/v0/general` by default
 
 ## AssemblyAI
 

--- a/goldenverba/.env.example
+++ b/goldenverba/.env.example
@@ -16,7 +16,7 @@
 # FIRECRAWL_API_KEY=
 
 # UNSTRUCTURED_API_KEY=
-# UNSTRUCTURED_API_URL=
+# UNSTRUCTURED_API_URL=https://api.unstructuredapp.io/general/v0/general
 
 # GITHUB_TOKEN=
 # GITLAB_TOKEN=


### PR DESCRIPTION
Updates references to the Unstructured API URL to the non-deprecated version. Note that this URL is also shown after logging into https://app.unstructured.io/ , as in the screenshot.
![image](https://github.com/user-attachments/assets/0ca48380-497f-46a3-a47d-2ce46a774d6f)
