### PR TITLE
Treat empty strings as invalid tokens

### DIFF
--- a/goldenverba/components/embedding/CohereEmbedder.py
+++ b/goldenverba/components/embedding/CohereEmbedder.py
@@ -24,9 +24,9 @@ class CohereEmbedder(Embedding):
 
         self.config["Model"] = InputConfig(
             type="dropdown",
-            value=models[0],
+            value=models[0] if models else "",
             description="Select a Cohere Embedding Model",
-            values=models,
+            values=models if models else [],
         )
 
         if os.getenv("COHERE_API_KEY") is None:

--- a/goldenverba/components/embedding/CohereEmbedder.py
+++ b/goldenverba/components/embedding/CohereEmbedder.py
@@ -5,7 +5,7 @@ import json
 
 from goldenverba.components.interfaces import Embedding
 from goldenverba.components.types import InputConfig
-from goldenverba.components.util import get_environment
+from goldenverba.components.util import get_environment, get_token
 
 from wasabi import msg
 
@@ -20,7 +20,7 @@ class CohereEmbedder(Embedding):
         self.name = "Cohere"
         self.description = "Vectorizes documents and queries using Cohere"
         self.url = os.getenv("COHERE_BASE_URL", "https://api.cohere.com/v1")
-        models = get_models(self.url, os.getenv("COHERE_API_KEY", None), "embed")
+        models = get_models(self.url, get_token("COHERE_API_KEY", None), "embed")
 
         self.config["Model"] = InputConfig(
             type="dropdown",
@@ -29,7 +29,7 @@ class CohereEmbedder(Embedding):
             values=models if models else [],
         )
 
-        if os.getenv("COHERE_API_KEY") is None:
+        if get_token("COHERE_API_KEY") is None:
             self.config["API Key"] = InputConfig(
                 type="password",
                 value="",
@@ -71,7 +71,7 @@ class CohereEmbedder(Embedding):
 
 def get_models(url: str, token: str, model_type: str):
     try:
-        if token is None:
+        if token is None or token == "":
             return [
                 "embed-english-v3.0",
                 "embed-multilingual-v3.0",

--- a/goldenverba/components/embedding/OpenAIEmbedder.py
+++ b/goldenverba/components/embedding/OpenAIEmbedder.py
@@ -8,7 +8,7 @@ from wasabi import msg
 
 from goldenverba.components.interfaces import Embedding
 from goldenverba.components.types import InputConfig
-from goldenverba.components.util import get_environment
+from goldenverba.components.util import get_environment, get_token
 
 
 class OpenAIEmbedder(Embedding):
@@ -20,7 +20,7 @@ class OpenAIEmbedder(Embedding):
         self.description = "Vectorizes documents and queries using OpenAI"
 
         # Fetch available models
-        api_key = os.getenv("OPENAI_API_KEY")
+        api_key = get_token("OPENAI_API_KEY")
         base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
         models = self.get_models(api_key, base_url)
 

--- a/goldenverba/components/generation/CohereGenerator.py
+++ b/goldenverba/components/generation/CohereGenerator.py
@@ -25,9 +25,9 @@ class CohereGenerator(Generator):
 
         self.config["Model"] = InputConfig(
             type="dropdown",
-            value=models[0],
+            value=models[0] if models else "",
             description="Select a Cohere Embedding Model",
-            values=models,
+            values=models if models else [],
         )
 
         if os.getenv("COHERE_API_KEY") is None:

--- a/goldenverba/components/generation/CohereGenerator.py
+++ b/goldenverba/components/generation/CohereGenerator.py
@@ -6,7 +6,7 @@ from typing import List, Dict, AsyncGenerator
 from goldenverba.components.interfaces import Generator
 from goldenverba.components.types import InputConfig
 from goldenverba.components.embedding.CohereEmbedder import get_models
-from goldenverba.components.util import get_environment
+from goldenverba.components.util import get_environment, get_token
 
 
 class CohereGenerator(Generator):
@@ -21,7 +21,7 @@ class CohereGenerator(Generator):
         self.url = os.getenv("COHERE_BASE_URL", "https://api.cohere.com/v1")
         self.context_window = 10000
 
-        models = get_models(self.url, os.getenv("COHERE_API_KEY", None), "chat")
+        models = get_models(self.url, get_token("COHERE_API_KEY", None), "chat")
 
         self.config["Model"] = InputConfig(
             type="dropdown",
@@ -30,7 +30,7 @@ class CohereGenerator(Generator):
             values=models if models else [],
         )
 
-        if os.getenv("COHERE_API_KEY") is None:
+        if get_token("COHERE_API_KEY") is None:
             self.config["API Key"] = InputConfig(
                 type="password",
                 value="",

--- a/goldenverba/components/generation/OpenAIGenerator.py
+++ b/goldenverba/components/generation/OpenAIGenerator.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 from goldenverba.components.interfaces import Generator
 from goldenverba.components.types import InputConfig
-from goldenverba.components.util import get_environment
+from goldenverba.components.util import get_environment, get_token
 import httpx
 import json
 
@@ -29,7 +29,7 @@ class OpenAIGenerator(Generator):
             values=models,
         )
 
-        if os.getenv("OPENAI_API_KEY") is None:
+        if get_token("OPENAI_API_KEY") is None:
             self.config["API Key"] = InputConfig(
                 type="password",
                 value="",

--- a/goldenverba/components/util.py
+++ b/goldenverba/components/util.py
@@ -51,6 +51,11 @@ def get_environment(config, value: str, env: str, error_msg: str) -> str:
         token = config[value].value
     else:
         token = os.environ.get(env)
-    if not token:
+    if not token or token == "":
         raise Exception(error_msg)
+    return token
+
+def get_token(env: str, default: str = None) -> str:
+    # return token, but treat empty string als None
+    token = tok if bool(tok := os.getenv(env, None)) else default
     return token


### PR DESCRIPTION
Verba's `docker_compose.yml` file maps session environment variables to the container using a pattern like `COHERE_API_KEY=$COHERE_API_KEY`.

When `os.environ.get("COHERE_API_KEY", None)` was called inside the container and the environment variable was not defined, an empty string (instead of None) was returned. Since empty strings weren't handled correctly, the Docker version of Verba failed to run without valid keys.

In `CohereEmbedder` and `CohereGenerator` the `get_models()` function returned None, causing a _TypeError: 'NoneType' object is not subscriptable_ (see #290).

For `OpenAIEmbedder` and `OpenAIGenerator`, no error was raised initially, but retrieval of current models was attempted without a valid token and triggered a _Failed to fetch OpenAI embedding models: 401 Client Error: Unauthorized for url: https://api.openai.com/v1/models_ .

This PR introduces a solution for both issues: a new utility function `get_token()`, which can replace `os.environ.get()` directly and handles empty strings. Later, it could be extended to a stricter, e.g. Regex-based validation, for valid tokens.

PS: _I aimed to follow the contributing guidelines, but the dev branch appears to contain version 1.0, so this pull request is directed to main. Running Black would reformat several files I haven't touched, so I skipped it. Additionally, I couldn't find tests for the Python parts. Apologies for any inconvenience._