### PR TITLE
fix: MarkdownChunker, retain subsection headers

### DIFF
--- a/goldenverba/components/chunking/MarkdownChunker.py
+++ b/goldenverba/components/chunking/MarkdownChunker.py
@@ -2,11 +2,36 @@ import contextlib
 
 with contextlib.suppress(Exception):
     from langchain_text_splitters import MarkdownHeaderTextSplitter
+    from langchain_core.documents import Document as LangChainDocument
 
 from goldenverba.components.chunk import Chunk
 from goldenverba.components.interfaces import Chunker
 from goldenverba.components.document import Document
 from goldenverba.components.interfaces import Embedding
+
+
+HEADERS_TO_SPLIT_ON = [
+    ("#", "Header 1"),
+    ("##", "Header 2"),
+    ("###", "Header 3"),
+]
+
+
+def get_header_values(
+    split_doc: LangChainDocument,
+) -> list[str]:
+    """
+    Get the text values of the headers in the LangChain Document resulting from a split.
+    """
+    # This function uses an explicit list of header keys because the LangChain Document
+    # metadata is a dictionary with arbitrary entries, some of which may not be headers.
+    header_keys = [header_key for _, header_key in HEADERS_TO_SPLIT_ON]
+
+    return [
+        header_value
+        for header_key in header_keys
+        if (header_value := split_doc.metadata.get(header_key)) is not None
+    ]
 
 
 class MarkdownChunker(Chunker):
@@ -31,11 +56,7 @@ class MarkdownChunker(Chunker):
     ) -> list[Document]:
 
         text_splitter = MarkdownHeaderTextSplitter(
-            headers_to_split_on=[
-                ("#", "Header 1"),
-                ("##", "Header 2"),
-                ("###", "Header 3"),
-            ]
+            headers_to_split_on=HEADERS_TO_SPLIT_ON
         )
 
         char_end_i = -1
@@ -45,16 +66,17 @@ class MarkdownChunker(Chunker):
             if len(document.chunks) > 0:
                 continue
 
-            for i, chunk in enumerate(text_splitter.split_text(document.content)):
-                
+            for i, split_doc in enumerate(text_splitter.split_text(document.content)):
+
                 chunk_text = ""
 
-                # append title and page content (should only be one header as we are splitting at header so index at 0), if a header is found
-                if len(chunk.metadata) > 0:
-                    chunk_text += list(chunk.metadata.values())[0] + "\n"
+                # Add header content to retain context and improve retrieval
+                header_values = get_header_values(split_doc)
+                for header_value in header_values:
+                    chunk_text += header_value + "\n"
 
                 # append page content (always there)
-                chunk_text += chunk.page_content
+                chunk_text += split_doc.page_content
 
                 char_start_i = char_end_i + 1
                 char_end_i = char_start_i + len(chunk_text)


### PR DESCRIPTION
Update MarkdownChunker to retain level 2 and level 3 Markdown headers in the chunk content for better retrieval. Previous logic was only grabbing the top-level header.

Closes #322

---
The LangChain `MarkdownHeaderTextSplitter` produces `Document` objects that carry around the containing header content as metadata values. There are possibly a number of ways to use this header metadata to improve the retrieval of relevant chunks, but I'm not changing the overall approach; this change just ensures that level 2 and level 3 headers are retained when this header text is added to the chunk content.

⚠️ As others have noted: I tried to follow the contribution guidelines, but the `dev` branch seems to pull in some other commits, so this pull request is directed to `main`. Also, I see there are no automated tests for the project yet. I'm happy to write tests, but didn't want to add test code for which there's no automated pipeline, so I'll skip for now.

I've tested my change manually:

```python
doc = Document(content="...")
await MarkdownChunker().chunk(config={}, documents=[doc])
print([chunk.content for chunk in doc.chunks])
```

... and through the Verba UI on a local deployment by importing the Markdown doc mentioned in the [issue](https://github.com/weaviate/Verba/issues/322).