### PR TITLE
fix: urllib to join ollama url domain to endpoint in place of string format

### DIFF
--- a/goldenverba/components/embedding/OllamaEmbedder.py
+++ b/goldenverba/components/embedding/OllamaEmbedder.py
@@ -2,6 +2,7 @@ import os
 import requests
 from wasabi import msg
 import aiohttp
+from urllib.parse import urljoin
 
 from goldenverba.components.interfaces import Embedding
 from goldenverba.components.types import InputConfig
@@ -33,7 +34,7 @@ class OllamaEmbedder(Embedding):
         data = {"model": model, "input": content}
 
         async with aiohttp.ClientSession() as session:
-            async with session.post(self.url + "/api/embed", json=data) as response:
+            async with session.post(urljoin(self.url, "/api/embed"), json=data) as response:
                 response.raise_for_status()
                 data = await response.json()
                 embeddings = data.get("embeddings", [])
@@ -42,7 +43,7 @@ class OllamaEmbedder(Embedding):
 
 def get_models(url: str):
     try:
-        response = requests.get(url + "/api/tags")
+        response = requests.get(urljoin(url, "/api/tags"))
         models = [model.get("name") for model in response.json().get("models")]
         if len(models) > 0:
             return models

--- a/goldenverba/components/generation/OllamaGenerator.py
+++ b/goldenverba/components/generation/OllamaGenerator.py
@@ -1,6 +1,7 @@
 import os
 import json
 import aiohttp
+from urllib.parse import urljoin
 from typing import List, Dict, AsyncGenerator
 
 from goldenverba.components.interfaces import Generator
@@ -35,7 +36,6 @@ class OllamaGenerator(Generator):
         conversation: List[Dict] = [],
     ) -> AsyncGenerator[Dict, None]:
         model = config.get("Model").value
-        url = f"{self.url}/api/chat"
         system_message = config.get("System Message").value
 
         if not self.url:
@@ -47,7 +47,7 @@ class OllamaGenerator(Generator):
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.post(url, json=data) as response:
+                async with session.post(urljoin(self.url, "/api/chat"), json=data) as response:
                     async for line in response.content:
                         if line.strip():
                             yield self._process_response(line)


### PR DESCRIPTION
Issue: https://github.com/weaviate/Verba/issues/315

DIscussion: https://forum.weaviate.io/t/vectorization-failed-404-http-host-docker-internal-11434-api-embed/7363

It was found that setting the OLLAMA_URL environment variable with a trailing forward slash resulted in the file import endpoint being unable to import files with 404 NOT FOUND for "/api/embed". This change ensures correct url formatting to fix this issue to improve developer experience.