### PR TITLE
Connect to custom OpenAI Server and retrieve models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.2.0] Investing in Testing (Suffering will never end)
+## [2.1.1] More Bugs!
+
+## Added
+
+- Dynamic model name retrieval for OpenAI Generator based on OpenAI URL and API Key (https://github.com/weaviate/Verba/issues/123) (https://github.com/weaviate/Verba/issues/362)
 
 ## [2.1.0] Fixing Bugs and Adding Friends
 

--- a/README.md
+++ b/README.md
@@ -448,4 +448,8 @@ You can learn more about Verba's architecture and implementation in its [technic
   - Verba is designed and optimized for single user usage only. There are no plans on supporting multiple users or role based access in the near future.
 
 - **Does Verba offer a API endpoint to use externally?**
+
   - No, right now Verba does not offer any useful API endpoints to interact with the application. The current FastAPI setup is optimized for the internal communication between the frontend and backend. It is not recommended to use it as a API endpoint. There are plans to add user-friendly
+
+- **How to connect to your custom OpenAI Server?**
+  - Set your custom OpenAI API Key and URL in the `.env` file, this will allow Verba to start up and retrieve the models from your custom OpenAI Server. `OPENAI_BASE_URL` is set to `https://api.openai.com/v1` by default.

--- a/goldenverba/components/generation/GroqGenerator.py
+++ b/goldenverba/components/generation/GroqGenerator.py
@@ -184,7 +184,6 @@ def get_models(url: str, api_key: str) -> List[str]:
         return models
 
     except Exception as e:
-        msg.info(f"Couldn't connect to Groq ({url})")
         return DEFAULT_MODEL_LIST
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="goldenverba",
-    version="2.1.0",
+    version="2.1.1",
     packages=find_packages(),
     python_requires=">=3.10.0,<3.13.0",
     entry_points={


### PR DESCRIPTION
This `PR` adds `get_models` function to the `OpenAIGenerator` which allows Verba to read model names from the server URL specified in `OPENAI_BASE_URL`


Related issues:
https://github.com/weaviate/Verba/issues/362
https://github.com/weaviate/Verba/issues/123