### PR TITLE
Improve custom OpenAI server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Below is a comprehensive list of the API keys and variables you may require:
 | OPENAI_EMBED_BASE_URL        | URL to OpenAI instance                                     | Use a different endpoint for embeddings                                                                                                                        |
 | OPENAI_MODEL        | The name of the model to be used when selecting OpenAI as a Generator                                    | Default: the first model in the list returned by the endpoint                                                                                                                        |
 | OPENAI_EMBED_MODEL        | The name of the OpenAI embedding model to be used when selecting OpenAI as an Embedder                                    | Default: `text-embedding-3-small`                                                                                                                        |
+| OPENAI_CUSTOM_EMBED        | `true` \| `false`                                    | Allow Verba to recognize custom embedding model names (not only OpenAI ones)                                                                            |
 | COHERE_API_KEY         | Your API Key                                               | Get Access to [Cohere](https://cohere.com/) Models                                                                            |
 | GROQ_API_KEY           | Your Groq API Key                                          | Get Access to [Groq](https://groq.com/) Models                                                                                |
 | NOVITA_API_KEY         | Your Novita API Key                                        | Get Access to [Novita AI](https://novita.ai?utm_source=github_verba&utm_medium=github_readme&utm_campaign=github_link) Models |
@@ -253,7 +254,7 @@ OPENAI_BASE_URL=YOUR-OPENAI_BASE_URL
 
 To specify a different endpoint for your embeddings, set the `OPENAI_EMBED_API_KEY` and `OPENAI_EMBED_BASE_URL` environment variables.
 
-If you are using a custom OpenAI Server for embeddings, ensure you set `CUSTOM_OPENAI_EMBED=true`. This will allow Verba to recognize custom embedding model names instead of the default OpenAI embedding model names.
+If you are using a custom OpenAI Server for embeddings, ensure you set `OPENAI_CUSTOM_EMBED=true`. This will allow Verba to recognize custom embedding model names instead of the default OpenAI embedding model names.
 
 ## HuggingFace
 
@@ -471,7 +472,7 @@ You can learn more about Verba's architecture and implementation in its [technic
 - **How to connect to your custom OpenAI Server?**
 
   - Set your custom OpenAI API Key and URL in the `.env` file, this will allow Verba to start up and retrieve the models from your custom OpenAI Server. `OPENAI_BASE_URL` is set to `https://api.openai.com/v1` by default.
-  - You can also set a different endpoint for your embeddings by configuring the `OPENAI_EMBED_API_KEY` and `OPENAI_EMBED_BASE_URL` environment variables and setting `CUSTOM_OPENAI_EMBED=true`. For more details, see [OpenAI Embeddings](#openai-embeddings).
+  - You can also set a different endpoint for your embeddings by configuring the `OPENAI_EMBED_API_KEY` and `OPENAI_EMBED_BASE_URL` environment variables and setting `OPENAI_CUSTOM_EMBED=true`. For more details, see [OpenAI Embeddings](#openai-embeddings).
 
 - **How to upload custom JSON files to Verba?**
   - Right now Verba does not support custom JSON structure. Instead the whole JSON will simply be dumped into the content field of the Verba document. You can read more about the Verba JSON Structure in the Technical Documentation [here](./TECHNICAL.md).

--- a/README.md
+++ b/README.md
@@ -167,7 +167,11 @@ Below is a comprehensive list of the API keys and variables you may require:
 | WEAVIATE_API_KEY_VERBA | API Credentials to your hosted Weaviate Cluster            | Connect to your [WCS](https://console.weaviate.cloud/) Cluster                                                                |
 | ANTHROPIC_API_KEY      | Your Anthropic API Key                                     | Get Access to [Anthropic](https://www.anthropic.com/) Models                                                                  |
 | OPENAI_API_KEY         | Your OpenAI Key                                            | Get Access to [OpenAI](https://openai.com/) Models                                                                            |
+| OPENAI_EMBED_API_KEY         | Your OpenAI Key                                            | Use a different endpoint for embeddings                                                                            |
 | OPENAI_BASE_URL        | URL to OpenAI instance                                     | Models                                                                                                                        |
+| OPENAI_EMBED_BASE_URL        | URL to OpenAI instance                                     | Use a different endpoint for embeddings                                                                                                                        |
+| OPENAI_MODEL        | The name of the model to be used when selecting OpenAI as a Generator                                    | Default: the first model in the list returned by the endpoint                                                                                                                        |
+| OPENAI_EMBED_MODEL        | The name of the OpenAI embedding model to be used when selecting OpenAI as an Embedder                                    | Default: `text-embedding-3-small`                                                                                                                        |
 | COHERE_API_KEY         | Your API Key                                               | Get Access to [Cohere](https://cohere.com/) Models                                                                            |
 | GROQ_API_KEY           | Your Groq API Key                                          | Get Access to [Groq](https://groq.com/) Models                                                                                |
 | NOVITA_API_KEY         | Your Novita API Key                                        | Get Access to [Novita AI](https://novita.ai?utm_source=github_verba&utm_medium=github_readme&utm_campaign=github_link) Models |
@@ -184,6 +188,7 @@ Below is a comprehensive list of the API keys and variables you may require:
 | UPSTAGE_API_KEY        | Your Upstage API Key                                       | Get Access to [Upstage](https://upstage.ai/) Models                                                                           |
 | UPSTAGE_BASE_URL       | URL to Upstage instance                                    | Models                                                                                                                        |
 | DEFAULT_DEPLOYMENT     | Local, Weaviate, Custom, Docker                            | Set the default deployment mode                                                                                               |
+| SYSYEM_MESSAGE_PROMPT     | Prompt text value                            | Default value starts with: "You are Verba, a chatbot for..."                                                                                               |
 
 ![API Keys in Verba](https://github.com/weaviate/Verba/blob/2.0.0/img/api_screen.png)
 
@@ -244,6 +249,11 @@ You can also add a `OPENAI_BASE_URL` to use proxies such as LiteLLM (https://git
 ```
 OPENAI_BASE_URL=YOUR-OPENAI_BASE_URL
 ```
+### OpenAI Embeddings
+
+To specify a different endpoint for your embeddings, set the `OPENAI_EMBED_API_KEY` and `OPENAI_EMBED_BASE_URL` environment variables.
+
+If you are using a custom OpenAI Server for embeddings, ensure you set `CUSTOM_OPENAI_EMBED=true`. This will allow Verba to recognize custom embedding model names instead of the default OpenAI embedding model names.
 
 ## HuggingFace
 
@@ -461,6 +471,7 @@ You can learn more about Verba's architecture and implementation in its [technic
 - **How to connect to your custom OpenAI Server?**
 
   - Set your custom OpenAI API Key and URL in the `.env` file, this will allow Verba to start up and retrieve the models from your custom OpenAI Server. `OPENAI_BASE_URL` is set to `https://api.openai.com/v1` by default.
+  - You can also set a different endpoint for your embeddings by configuring the `OPENAI_EMBED_API_KEY` and `OPENAI_EMBED_BASE_URL` environment variables and setting `CUSTOM_OPENAI_EMBED=true`. For more details, see [OpenAI Embeddings](#openai-embeddings).
 
 - **How to upload custom JSON files to Verba?**
   - Right now Verba does not support custom JSON structure. Instead the whole JSON will simply be dumped into the content field of the Verba document. You can read more about the Verba JSON Structure in the Technical Documentation [here](./TECHNICAL.md).

--- a/goldenverba/components/embedding/OpenAIEmbedder.py
+++ b/goldenverba/components/embedding/OpenAIEmbedder.py
@@ -138,7 +138,7 @@ class OpenAIEmbedder(Embedding):
             response = requests.get(f"{url}/models", headers=headers)
             response.raise_for_status()
             fetch_models = [model["id"] for model in response.json()["data"]]
-            if not os.getenv("CUSTOM_OPENAI_EMBED", False):
+            if not os.getenv("OPENAI_CUSTOM_EMBED", False):
                 # this is not a custom OpenAI so we can filter out non-embedding OpenAI models
                 fetch_models = [
                     model_id for model_id in fetch_models if "embedding" in model_id

--- a/goldenverba/components/embedding/OpenAIEmbedder.py
+++ b/goldenverba/components/embedding/OpenAIEmbedder.py
@@ -19,16 +19,25 @@ class OpenAIEmbedder(Embedding):
         self.name = "OpenAI"
         self.description = "Vectorizes documents and queries using OpenAI"
 
+        # If a different key is set for the OpenAI embedding, use it
+        api_key = get_token("OPENAI_EMBED_API_KEY")
+        api_key = api_key if api_key else get_token("OPENAI_API_KEY")
+
         # Fetch available models
-        api_key = get_token("OPENAI_API_KEY")
-        base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        base_url = os.getenv("OPENAI_EMBED_BASE_URL")
+        base_url = (
+            base_url
+            if base_url
+            else os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        )
         models = self.get_models(api_key, base_url)
 
         # Set up configuration
+        default_model = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small")
         self.config = {
             "Model": InputConfig(
                 type="dropdown",
-                value="text-embedding-3-small",
+                value=default_model,
                 description="Select an OpenAI Embedding Model",
                 values=models,
             )
@@ -39,10 +48,13 @@ class OpenAIEmbedder(Embedding):
             self.config["API Key"] = InputConfig(
                 type="password",
                 value="",
-                description="OpenAI API Key (or set OPENAI_API_KEY env var)",
+                description="OpenAI API Key (or set OPENAI_EMBED_API_KEY or OPENAI_API_KEY env var)",
                 values=[],
             )
-        if os.getenv("OPENAI_BASE_URL") is None:
+        if (
+            os.getenv("OPENAI_EMBED_BASE_URL") is None
+            and os.getenv("OPENAI_BASE_URL") is None
+        ):
             self.config["URL"] = InputConfig(
                 type="text",
                 value=base_url,
@@ -53,12 +65,20 @@ class OpenAIEmbedder(Embedding):
     async def vectorize(self, config: dict, content: List[str]) -> List[List[float]]:
         """Vectorize the input content using OpenAI's API."""
         model = config.get("Model", {"value": "text-embedding-ada-002"}).value
+        key_name = (
+            "OPENAI_EMBED_API_KEY"
+            if get_token("OPENAI_EMBED_API_KEY")
+            else "OPENAI_API_KEY"
+        )
         api_key = get_environment(
-            config, "API Key", "OPENAI_API_KEY", "No OpenAI API Key found"
+            config, "API Key", key_name, "No OpenAI API Key found"
         )
-        base_url = get_environment(
-            config, "URL", "OPENAI_BASE_URL", "No OpenAI URL found"
+        base_url_name = (
+            "OPENAI_EMBED_BASE_URL"
+            if os.getenv("OPENAI_EMBED_BASE_URL")
+            else "OPENAI_BASE_URL"
         )
+        base_url = get_environment(config, "URL", base_url_name, "No OpenAI URL found")
 
         headers = {
             "Content-Type": "application/json",
@@ -117,11 +137,13 @@ class OpenAIEmbedder(Embedding):
             headers = {"Authorization": f"Bearer {token}"}
             response = requests.get(f"{url}/models", headers=headers)
             response.raise_for_status()
-            return [
-                model["id"]
-                for model in response.json()["data"]
-                if "embedding" in model["id"]
-            ]
+            fetch_models = [model["id"] for model in response.json()["data"]]
+            if not os.getenv("CUSTOM_OPENAI_EMBED", False):
+                # this is not a custom OpenAI so we can filter out non-embedding OpenAI models
+                fetch_models = [
+                    model_id for model_id in fetch_models if "embedding" in model_id
+                ]
+            return fetch_models
         except Exception as e:
             msg.info(f"Failed to fetch OpenAI embedding models: {str(e)}")
             return [

--- a/goldenverba/components/generation/OpenAIGenerator.py
+++ b/goldenverba/components/generation/OpenAIGenerator.py
@@ -25,11 +25,12 @@ class OpenAIGenerator(Generator):
         api_key = get_token("OPENAI_API_KEY")
         base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
         models = self.get_models(api_key, base_url)
+        default_model = os.getenv("OPENAI_MODEL", models[0])
 
         self.config["Model"] = InputConfig(
             type="dropdown",
-            value=models[0],
-            description="Select an OpenAI Embedding Model",
+            value=default_model,
+            description="Select an OpenAI Model",
             values=models,
         )
 

--- a/goldenverba/components/interfaces.py
+++ b/goldenverba/components/interfaces.py
@@ -1,3 +1,5 @@
+import os
+
 from goldenverba.components.document import Document
 from goldenverba.server.types import FileConfig
 from goldenverba.components.types import InputConfig
@@ -151,9 +153,12 @@ class Generator(VerbaComponent):
     def __init__(self):
         super().__init__()
         self.context_window = 5000
+        default_prompt = "You are Verba, a chatbot for Retrieval Augmented Generation (RAG). You will receive a user query and context pieces that have a semantic similarity to that query. Please answer these user queries only with the provided context. Mention documents you used from the context if you use them to reduce hallucination. If the provided documentation does not provide enough information, say so. If the user asks questions about you as a chatbot specifially, answer them naturally. If the answer requires code examples encapsulate them with ```programming-language-name ```. Don't do pseudo-code."
+        prompt = os.getenv("SYSYEM_MESSAGE_PROMPT", default_prompt)
+        msg.info(f"Using prompt: {prompt}")
         self.config["System Message"] = InputConfig(
             type="textarea",
-            value="You are Verba, a chatbot for Retrieval Augmented Generation (RAG). You will receive a user query and context pieces that have a semantic similarity to that query. Please answer these user queries only with the provided context. Mention documents you used from the context if you use them to reduce hallucination. If the provided documentation does not provide enough information, say so. If the user asks questions about you as a chatbot specifially, answer them naturally. If the answer requires code examples encapsulate them with ```programming-language-name ```. Don't do pseudo-code.",
+            value=prompt,
             description="System Message",
             values=[],
         )

--- a/goldenverba/components/interfaces.py
+++ b/goldenverba/components/interfaces.py
@@ -155,7 +155,6 @@ class Generator(VerbaComponent):
         self.context_window = 5000
         default_prompt = "You are Verba, a chatbot for Retrieval Augmented Generation (RAG). You will receive a user query and context pieces that have a semantic similarity to that query. Please answer these user queries only with the provided context. Mention documents you used from the context if you use them to reduce hallucination. If the provided documentation does not provide enough information, say so. If the user asks questions about you as a chatbot specifially, answer them naturally. If the answer requires code examples encapsulate them with ```programming-language-name ```. Don't do pseudo-code."
         prompt = os.getenv("SYSYEM_MESSAGE_PROMPT", default_prompt)
-        msg.info(f"Using prompt: {prompt}")
         self.config["System Message"] = InputConfig(
             type="textarea",
             value=prompt,


### PR DESCRIPTION
Issue: https://github.com/weaviate/Verba/issues/123

Add customization to improve support of custom OpenAI server:
- Added support for setting a different (potentially custom) OpenAI server endpoint for embeddings
- Added support for setting the default model name when selecting OpenAI as a Generator
- Added support for setting the default embedding model name when selecting OpenAI as an Embedder 
- Added support for a customizable system message prompt


Documentation updates:

* `README.md`:
  - Documented all new environment variables
  - Update FAQ for: **How to connect to your custom OpenAI Server?**

Codebase improvements:

* `goldenverba/components/embedding/OpenAIEmbedder.py`:
  * Support custom embedding endpoint controlled by `OPENAI_EMBED_API_KEY`, `OPENAI_EMBED_BASE_URL`, `OPENAI_CUSTOM_EMBED` environment variables
  * Support a default embedding model specified by the `OPENAI_EMBED_MODEL` environment variable
* `goldenverba/components/generation/OpenAIGenerator.py`: support a default model specified by the `OPENAI_MODEL` environment variable.
* `goldenverba/components/interfaces.py`: Added support for a customizable system message prompt via the `SYSYEM_MESSAGE_PROMPT` environment variable