### PR TITLE
bugfix: Fix chunk deserialization from JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 .python-version
 *.egg-info
 venv
+.venv
 venv*
 dist
 build

--- a/goldenverba/components/chunk.py
+++ b/goldenverba/components/chunk.py
@@ -40,12 +40,13 @@ class Chunk:
         """Construct a Chunk object from a dictionary."""
         chunk = cls(
             content=data.get("content", ""),
-            title=data.get("title", ""),
             chunk_id=data.get("chunk_id", 0),
             start_i=data.get("start_i", 0),
             end_i=data.get("end_i", 0),
             content_without_overlap=data.get("content_without_overlap", ""),
-            labels=data.get("labels", []),
         )
-        chunk.doc_uuid = (data.get("doc_uuid", ""),)
+        chunk.title = data.get("title", "")
+        chunk.labels = data.get("labels", [])
+        chunk.pca = data.get("pca", [0, 0, 0])
+        chunk.doc_uuid = data.get("doc_uuid", "")
         return chunk

--- a/goldenverba/tests/chunk/test_chunk.py
+++ b/goldenverba/tests/chunk/test_chunk.py
@@ -1,0 +1,30 @@
+from goldenverba.components.chunk import Chunk
+
+
+def test_chunk_json_serialization_round_trip():
+    original_chunk = Chunk(
+        content="Chunk content",
+        content_without_overlap="Chunk",
+        chunk_id="chunk-1",
+        start_i=5,
+        end_i=15,
+    )
+    original_chunk.title = "Chunk Title"
+    original_chunk.labels = ["invoice", "important"]
+    original_chunk.doc_uuid = "doc-123"
+    original_chunk.pca = [0.1, 0.2, 0.3]
+
+    restored_chunk = Chunk.from_json(original_chunk.to_json())
+
+    assert restored_chunk.content == original_chunk.content
+    assert (
+        restored_chunk.content_without_overlap == original_chunk.content_without_overlap
+    )
+    assert restored_chunk.chunk_id == original_chunk.chunk_id
+    assert restored_chunk.start_i == original_chunk.start_i
+    assert restored_chunk.end_i == original_chunk.end_i
+    assert restored_chunk.title == original_chunk.title
+    assert restored_chunk.labels == original_chunk.labels
+    assert restored_chunk.doc_uuid == original_chunk.doc_uuid
+    assert restored_chunk.pca == original_chunk.pca
+    assert isinstance(restored_chunk.doc_uuid, str)


### PR DESCRIPTION
Improved the serialization / deserialization logic for the `Chunk` class, ensuring that all relevant attributes are correctly handled during JSON round-trips. It also adds a comprehensive test to verify this behavior.

Enhancements to `Chunk` serialization/deserialization:

* Updated the `from_json` method in `chunk.py` to properly set the `title`, `labels`, `pca`, and `doc_uuid` attributes when constructing a `Chunk` from a dictionary. This ensures that these fields are preserved and correctly restored during deserialization.

Testing improvements:

* Added a new test, `test_chunk_json_serialization_round_trip`, in `test_chunk.py` to verify that a `Chunk` object can be serialized to JSON and deserialized back without loss of data for all key attributes, including `title`, `labels`, `doc_uuid`, and `pca`.

Also, added .venv to .gitignore